### PR TITLE
Run tests with moto server (fixes #6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=flake8
 install:
-    - pip install tox
+    - pip install tox moto
+before_script:
+    - moto_server s3bucket_path -H 0.0.0.0 -p 5000 &
 script:
     - tox -e $TOX_ENV
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,22 @@ TODO
 * Validate API
 
 
+Run tests
+---------
+
+Install `Tox <https://tox.readthedocs.org/>`_ and `Moto <https://github.com/spulec/moto>`_, a fake Amazon S3 server: ::
+
+    pip install tox moto
+
+Run a standalone S3 server in a separate terminal: ::
+
+    moto_server s3bucket_path -H 0.0.0.0 -p 5000
+
+Run the tests suite: ::
+
+    tox
+
+
 Notes
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,6 @@ TODO
 * Simple fonctionnal test with real Kinto on TravisCI
 * Handle default bucket
 * Validate API
-* Check record permissions
 
 
 Notes

--- a/kinto_attachment/tests/__init__.py
+++ b/kinto_attachment/tests/__init__.py
@@ -1,10 +1,10 @@
 import uuid
 import os
 
-import mock
 import webtest
 from cliquet import utils as cliquet_utils
 from cliquet.tests import support as cliquet_support
+from pyramid_storage.s3 import S3FileStorage
 
 
 SAMPLE_SCHEMA = {
@@ -99,9 +99,21 @@ class BaseWebTestLocal(BaseWebTest):
 class BaseWebTestS3(BaseWebTest):
     config = 'config/s3.ini'
 
-    def upload(self, *args, **kwargs):
-        # XXX: use moto_server instead.
-        patch = mock.patch('pyramid_storage.s3.S3FileStorage.save_file',
-                           return_value='upload.jpg')
-        with patch.start():
-            return super(BaseWebTestS3, self).upload(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        self._bucket_created = False
+        super(BaseWebTestS3, self).__init__(*args, **kwargs)
+
+    def make_app(self):
+        app = super(BaseWebTestS3, self).make_app()
+
+        # Create bucket if necessary
+        if not self._bucket_created:
+            prefix = 'kinto.attachment.'
+            settings = app.app.registry.settings
+            fs = S3FileStorage.from_settings(settings, prefix=prefix)
+
+            bucket_name = settings[prefix + 'aws.bucket_name']
+            fs.get_connection().create_bucket(bucket_name)
+            self._bucket_created = True
+
+        return app

--- a/kinto_attachment/tests/__init__.py
+++ b/kinto_attachment/tests/__init__.py
@@ -100,20 +100,20 @@ class BaseWebTestS3(BaseWebTest):
     config = 'config/s3.ini'
 
     def __init__(self, *args, **kwargs):
-        self._bucket_created = False
+        self._s3_bucket_created = False
         super(BaseWebTestS3, self).__init__(*args, **kwargs)
 
     def make_app(self):
         app = super(BaseWebTestS3, self).make_app()
 
-        # Create bucket if necessary
-        if not self._bucket_created:
+        # Create the S3 bucket if necessary
+        if not self._s3_bucket_created:
             prefix = 'kinto.attachment.'
             settings = app.app.registry.settings
             fs = S3FileStorage.from_settings(settings, prefix=prefix)
 
             bucket_name = settings[prefix + 'aws.bucket_name']
             fs.get_connection().create_bucket(bucket_name)
-            self._bucket_created = True
+            self._s3_bucket_created = True
 
         return app

--- a/kinto_attachment/tests/config/s3.ini
+++ b/kinto_attachment/tests/config/s3.ini
@@ -4,6 +4,10 @@ kinto.userid_hmac_secret = some-secret-string
 multiauth.policies = basicauth
 
 kinto.includes = kinto_attachment
-kinto.attachment.aws.access_key = <AWS access key>
-kinto.attachment.aws.secret_key = <AWS secret key>
-kinto.attachment.aws.bucket = myfiles
+kinto.attachment.aws.host = localhost
+kinto.attachment.aws.port = 5000
+kinto.attachment.aws.is_secure = false
+kinto.attachment.aws.use_path_style = true
+kinto.attachment.aws.access_key = aws
+kinto.attachment.aws.secret_key = aws
+kinto.attachment.aws.bucket_name = myfiles

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -3,7 +3,7 @@ import os
 from pyramid_storage.interfaces import IFileStorage
 from cliquet.tests.support import unittest
 
-from . import BaseWebTestLocal, BaseWebTestS3
+from . import BaseWebTestLocal, BaseWebTestS3, get_user_headers
 
 
 class UploadTest(object):

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -84,9 +84,8 @@ class LocalDeleteTest(DeleteTest, BaseWebTestLocal, unittest.TestCase):
     pass
 
 
-# XXX: Use moto server
-# class S3DeleteTest(DeleteTest, BaseWebTestS3, unittest.TestCase):
-#     pass
+class S3DeleteTest(DeleteTest, BaseWebTestS3, unittest.TestCase):
+    pass
 
 
 class AttachmentViewTest(BaseWebTestLocal, unittest.TestCase):

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -146,6 +146,52 @@ class AttachmentViewTest(BaseWebTestLocal, unittest.TestCase):
         self.assertEqual(resp.json['message'],
                          'body: File extension is not allowed.')
 
+    # Permissions.
+
+    def test_upload_refused_if_not_authenticated(self):
+        self.headers.pop('Authorization')
+        self.upload(status=401)
+
+    def test_upload_refused_if_not_allowed(self):
+        self.headers.update(get_user_headers('jean-louis'))
+        self.upload(status=403)
+
+    def test_upload_replace_refused_if_only_create_allowed(self):
+        # Allow any authenticated to write in this bucket.
+        perm = {'permissions': {'record:create': ['system.Authenticated']}}
+        self.app.patch_json('/buckets/fennec/collections/fonts',
+                            perm, headers=self.headers)
+        self.upload(status=201)
+
+        self.headers.update(get_user_headers('jean-louis'))
+        self.upload(status=403)
+
+    def test_upload_create_accepted_if_create_allowed(self):
+        # Allow any authenticated to write in this bucket.
+        perm = {'permissions': {'record:create': ['system.Authenticated']}}
+        self.app.patch_json('/buckets/fennec/collections/fonts',
+                            perm, headers=self.headers)
+
+        self.headers.update(get_user_headers('jean-louis'))
+        self.upload(status=201)
+
+    def test_upload_create_accepted_if_write_allowed(self):
+        # Allow any authenticated to write in this bucket.
+        perm = {'permissions': {'write': ['system.Authenticated']}}
+        self.app.patch_json('/buckets/fennec', perm, headers=self.headers)
+
+        self.headers.update(get_user_headers('jean-louis'))
+        self.upload(status=201)
+
+    def test_upload_replace_accepted_if_write_allowed(self):
+        # Allow any authenticated to write in this bucket.
+        perm = {'permissions': {'write': ['system.Authenticated']}}
+        self.app.patch_json('/buckets/fennec', perm, headers=self.headers)
+        self.upload(status=201)
+
+        self.headers.update(get_user_headers('jean-louis'))
+        self.upload(status=200)
+
 #
 # XXX: see bug https://github.com/Kinto/kinto/issues/277
 #

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     webtest
     https://github.com/mozilla-services/cliquet/tarball/master
     https://github.com/Kinto/kinto/tarball/master
+    https://github.com/leplatrem/pyramid_storage/tarball/add-s3-options
 install_command = pip install --pre {opts} {packages}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ deps =
     mock
     unittest2
     webtest
+    https://github.com/mozilla-services/cliquet/tarball/master
+    https://github.com/Kinto/kinto/tarball/master
 install_command = pip install --pre {opts} {packages}
 
 [testenv:flake8]


### PR DESCRIPTION
Based on #13 

* [x] Plug tox with pyramid_storage s3 options branch https://github.com/leplatrem/pyramid_storage/tree/add-s3-options
* [x] Document that `moto_server s3bucket_path -H 0.0.0.0 -p 5000` must be run before tests
* [x] Install/run `moto_server` on travis
