### PR TITLE
Expose the API capability attachments in the root URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 0.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New feature**
+
+- Expose the API capability ``attachments`` in the root URL.
 
 
 0.2.0 (2015-12-21)

--- a/kinto_attachment/__init__.py
+++ b/kinto_attachment/__init__.py
@@ -13,6 +13,11 @@ def includeme(config):
     storage_settings.setdefault('storage.extensions', 'any')
     config.add_settings(storage_settings)
 
+    # # Expose capability.
+    config.add_api_capability("attachments",
+                              description="Add file attachments to records",
+                              url="https://github.com/Kinto/kinto-attachment/")
+
     # Advertise public setting.
     config.registry.public_settings.add('attachment.base_url')
 

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -4,6 +4,16 @@ from . import BaseWebTestLocal
 
 
 class HelloViewTest(BaseWebTestLocal, unittest.TestCase):
+    def test_capability_is_exposed(self):
+        resp = self.app.get('/')
+        capabilities = resp.json['capabilities']
+        self.assertIn('attachments', capabilities)
+        expected = {
+            "description": "Add file attachments to records",
+            "url": "https://github.com/Kinto/kinto-attachment/",
+        }
+        self.assertEqual(expected, capabilities['attachments'])
+
     def test_public_url_is_provided_in_public_settings(self):
         resp = self.app.get('/')
         settings = resp.json['settings']

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('CHANGELOG.rst') as history_file:
 
 requirements = [
     'boto',
-    'kinto',
+    'kinto>=1.11.0',
     'pyramid_storage>=0.1.0',
 ]
 


### PR DESCRIPTION
@n1k0 r?