### PR TITLE
Prevent attachment attributes to be modified manually (fixes #83)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,9 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
 
+- Prevent ``attachment`` attributes to be modified manually (fixes #83)
 
 0.7.0 (2016-06-10)
 ------------------

--- a/kinto_attachment/listeners.py
+++ b/kinto_attachment/listeners.py
@@ -26,7 +26,7 @@ def on_delete_record(event):
             for_resources=('record',),
             for_actions=(ACTIONS.UPDATE,))
 def on_update_record(event):
-    if event.request.bound_data.pop('attachment_auto', False):
+    if getattr(event.request, '_attachment_auto_save', False):
         # Record attributes are being by the plugin itself.
         return
 

--- a/kinto_attachment/listeners.py
+++ b/kinto_attachment/listeners.py
@@ -1,5 +1,7 @@
 from kinto.core.events import ResourceChanged, ACTIONS
+from kinto.core.errors import http_error
 from pyramid.events import subscriber
+from pyramid.exceptions import HTTPBadRequest
 
 from . import utils
 
@@ -18,3 +20,22 @@ def on_delete_record(event):
     filter_field = '%s_uri' % resource_name
     uri = event.payload['uri']
     utils.delete_attachment(event.request, link_field=filter_field, uri=uri)
+
+
+@subscriber(ResourceChanged,
+            for_resources=('record',),
+            for_actions=(ACTIONS.UPDATE,))
+def on_update_record(event):
+    if event.request.bound_data.pop('attachment_auto', False):
+        # Record attributes are being by the plugin itself.
+        return
+
+    # A user is changing the record, make sure attachment metadata is not
+    # altered manually.
+    for change in event.impacted_records:
+        attachment_before = change['old'].get('attachment')
+        attachment_after = change['new'].get('attachment')
+        if attachment_before and attachment_after:
+            if attachment_before != attachment_after:
+                error_msg = "Attachment metadata cannot be modified."
+                raise http_error(HTTPBadRequest(), message=error_msg)

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -197,6 +197,14 @@ class AttachmentViewTest(object):
         self.assertEqual(resp.json['data']['family'], 'sans')
         self.assertEqual(resp.json['data']['author'], 'frutiger')
 
+    def test_record_attachment_metadata_cannot_be_removed_manually(self):
+        self.upload(params=[('data', '{"family": "sans"}')])
+        body = {'data': {'attachment': {'manual': 'true'}}}
+        resp = self.app.patch_json(self.record_uri, body, headers=self.headers,
+                                   status=400)
+        self.assertIn('Attachment metadata cannot be modified',
+                      resp.json['message'])
+
     def test_record_is_created_with_appropriate_permissions(self):
         self.upload()
         current_principal = ("basicauth:c6c27f0c7297ba7d4abd2a70c8a2cb88a06a3"

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -87,8 +87,10 @@ def patch_record(record, request):
     # Simulate update of fields.
     request.validated = record
     request.body = json.dumps(record).encode('utf-8')
+    request.bound_data['attachment_auto'] = True
     resource = Record(request, context)
     request.current_resource_name = 'record'
+
     try:
         saved = resource.patch()
     except httpexceptions.HTTPNotFound:

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -87,9 +87,9 @@ def patch_record(record, request):
     # Simulate update of fields.
     request.validated = record
     request.body = json.dumps(record).encode('utf-8')
-    request.bound_data['attachment_auto'] = True
     resource = Record(request, context)
     request.current_resource_name = 'record'
+    setattr(request, '_attachment_auto_save', True)  # Flag in update listener.
 
     try:
         saved = resource.patch()


### PR DESCRIPTION
Main challenge was to distinguish manual update from plugin change (e.g. replace attachment updates records attributes)

too hacky?


@Natim r?