### PR TITLE
Prevent crash when filename is not provided (fixes #81)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,9 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
 
+- Prevent crash when filename is not provided (fixes #81)
 
 0.7.0 (2016-06-10)
 ------------------

--- a/kinto_attachment/tests/test_utils.py
+++ b/kinto_attachment/tests/test_utils.py
@@ -1,5 +1,5 @@
+import cgi
 from six import BytesIO
-import mock
 
 from kinto.tests.core.support import unittest
 from kinto_attachment.utils import save_file
@@ -36,7 +36,7 @@ class _Request(object):
 class TestUtils(unittest.TestCase):
 
     def test_save_file_gzip(self):
-        my_font = mock.Mock()
+        my_font = cgi.FieldStorage()
         my_font.filename = 'font.ttf'
         my_font.file = BytesIO(b'content')
         my_font.type = 'application/x-font'
@@ -46,7 +46,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue('original' in res)
 
     def test_save_file_not_gzip(self):
-        my_font = mock.Mock()
+        my_font = cgi.FieldStorage()
         my_font.filename = 'font.ttf'
         my_font.file = BytesIO(b'content')
         my_font.type = 'application/x-font'

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -216,6 +216,12 @@ class AttachmentViewTest(object):
         resp = self.upload(params=[('data', '{"author": 12}')], status=400)
         self.assertIn("12 is not of type 'string'", resp.json['message'])
 
+    def test_attachment_must_have_a_filename(self):
+        resp = self.upload(files=[(self.file_field, b'', b'--fake--')],
+                           status=400)
+        self.assertEqual(resp.json['message'],
+                         'body: Filename is required.')
+
     def test_upload_refused_if_extension_not_allowed(self):
         resp = self.upload(files=[(self.file_field, b'virus.exe',
                                    b'--fake--')], status=400)

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -1,3 +1,4 @@
+import cgi
 import json
 import hashlib
 import gzip
@@ -123,6 +124,10 @@ def save_file(content, request, randomize=True, gzipped=False):
     folder = folder_pattern.format(**request.matchdict) or None
 
     # Read file to compute hash.
+    if not isinstance(content, cgi.FieldStorage):
+        error_msg = 'Filename is required.'
+        raise_invalid(request, location='body', description=error_msg)
+
     content.file.seek(0)
     filecontent = content.file.read()
 


### PR DESCRIPTION
@Natim r?

I thought I could set the filename to `unknown.bin` and instantiate a `FieldStorage` but the python 2/3 compat was hard to keep fancy