### PR TITLE
Makefile: replace variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(INSTALL_STAMP): $(PYTHON) setup.py
 
 virtualenv: $(PYTHON)
 $(PYTHON):
-	virtualenv $(VENV)
+	$(VIRTUALENV) $(VENV)
 
 build-requirements:
 	$(VIRTUALENV) $(TEMPDIR)


### PR DESCRIPTION
This helps ensure that users get a Python 3.5 venv.

I'm not sure about this fix; it's a change I made locally that seemed to work, but maybe there are tox or travis-related reasons why we don't want this. One way or another, it can get merged later, or not.

r? @Natim 