### PR TITLE
Add GZIP encoded S3 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 Changelog
 =========
 
-2.0.2 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- As support for the ``Content-Encoding`` header with the S3Backend (#132)
 
 
 2.0.1 (2017-04-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 **New features**
 
-- As support for the ``Content-Encoding`` header with the S3Backend (#132)
+- Add support for the ``Content-Encoding`` header with the S3Backend (#132)
 
 
 2.0.1 (2017-04-06)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ moto:
 tests-once: install
 	$(VENV)/bin/py.test kinto_attachment/tests --cov-report term-missing --cov-fail-under 100 --cov kinto_attachment
 
+flake8:
+	$(VENV)/bin/pip install -U flake8
+	$(VENV)/bin/flake8 kinto_attachment
+
 tests:
 	$(VENV)/bin/tox
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,8 @@ If you want uploaded files to get gzipped when stored:
 The ``use_content_encoding`` option
 -----------------------------------
 
-If you want uploaded files to be Gzipped and automatically unzipped with S3 you can activate the Content-Encoding header:
+If you want uploaded files to be Gzipped and automatically unzipped on the client side
+when downloading with S3 you can activate the content encoding setting:
 
 .. code-block:: ini
 
@@ -60,28 +61,29 @@ can use the resource configuration key:
 
 .. code-block:: ini
 
-	# For a whole bucket (/buckets/fennec-staging)
+    # For a whole bucket (/buckets/fennec-staging)
     kinto.attachment.resources.fennec-staging.use_content_encoding = false
     kinto.attachment.resources.fennec-staging.gzipped = true
 
-	# Or for a specific collection in it (/buckets/fingerprinting-defenses-staging/fonts)
+    # Or for a specific collection in it (/buckets/fingerprinting-defenses-staging/fonts)
     kinto.attachment.resources.fingerprinting-defenses-staging_fonts.use_content_encoding = true
 
-Be careful, ``use_content_encoding`` will force the gzipping of the files
-for the S3 storage but the metadata will look like it wasn't compressed.
+Be careful, ``use_content_encoding`` automatically sets ``gzipped =
+true`` with the S3 storage but the metadata will look like it wasn't
+compressed.
 
 In case you want to use the ``gzipped`` option you need to also make
 sure that ``use_content_encoding`` is set to `False`.
 
-You can say that you want to use ``Content-Encoding`` everywhere but for
+You can say that you want to use content encoding everywhere but for
 the ``fennec-staging`` bucket:
 
 .. code-block:: ini
 
-	# Global setting
-	kinto.attachment.use_content_encoding = true
+    # Global setting
+    kinto.attachment.use_content_encoding = true
 
-	# For a whole bucket (/buckets/fennec-staging)
+    # For a whole bucket (/buckets/fennec-staging)
     kinto.attachment.resources.fennec-staging.use_content_encoding = false
     kinto.attachment.resources.fennec-staging.gzipped = true
 
@@ -90,10 +92,10 @@ Or that you want to use ``gzipped`` everywhere but for the
 
 .. code-block:: ini
 
-	# Global default setting
-	kinto.attachment.gzipped = true
+    # Global default setting
+    kinto.attachment.gzipped = true
 
-	# For a whole bucket (/buckets/fennec-staging)
+    # For a whole bucket (/buckets/fennec-staging)
     kinto.attachment.resources.fingerprinting-defenses-staging.use_content_encoding = true
 
 
@@ -200,7 +202,7 @@ You can overwite that option by passing a ``?gzipped=true`` in the QueryString
 to specifically gzip some files.
 
 By default, the server will serve the gzip file, if you want the HTTP
-client to automatically decompress the file while loading it you can
+client to automatically decompress the file while loading it from S3 you can
 specify it when uploading the file by passing a ``?use_content_encoding=true``
 
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ In the Kinto project settings
     kinto.attachment.keep_old_files = true
 
 
+The ``gzipped`` option
+----------------------
+
 If you want uploaded files to get gzipped when stored:
 
 .. code-block:: ini
@@ -42,11 +45,69 @@ If you want uploaded files to get gzipped when stored:
     kinto.attachment.gzipped = true
 
 
+The ``use_content_encoding`` option
+-----------------------------------
+
+If you want uploaded files to be Gzipped and automatically unzipped with S3 you can activate the Content-Encoding header:
+
+.. code-block:: ini
+
+    kinto.attachment.use_content_encoding = true
+
+In case you want to activate ``gzipped`` for some buckets or
+collections and activate ``use_content_encoding`` for some other, you
+can use the resource configuration key:
+
+.. code-block:: ini
+
+	# For a whole bucket (/buckets/fennec-staging)
+    kinto.attachment.resources.fennec-staging.use_content_encoding = false
+    kinto.attachment.resources.fennec-staging.gzipped = true
+
+	# Or for a specific collection in it (/buckets/fingerprinting-defenses-staging/fonts)
+    kinto.attachment.resources.fingerprinting-defenses-staging_fonts.use_content_encoding = true
+
+Be careful, ``use_content_encoding`` will force the gzipping of the files
+for the S3 storage but the metadata will look like it wasn't compressed.
+
+In case you want to use the ``gzipped`` option you need to also make
+sure that ``use_content_encoding`` is set to `False`.
+
+You can say that you want to use ``Content-Encoding`` everywhere but for
+the ``fennec-staging`` bucket:
+
+.. code-block:: ini
+
+	# Global setting
+	kinto.attachment.use_content_encoding = true
+
+	# For a whole bucket (/buckets/fennec-staging)
+    kinto.attachment.resources.fennec-staging.use_content_encoding = false
+    kinto.attachment.resources.fennec-staging.gzipped = true
+
+Or that you want to use ``gzipped`` everywhere but for the
+``fingerprinting-defenses-staging`` bucket:
+
+.. code-block:: ini
+
+	# Global default setting
+	kinto.attachment.gzipped = true
+
+	# For a whole bucket (/buckets/fennec-staging)
+    kinto.attachment.resources.fingerprinting-defenses-staging.use_content_encoding = true
+
+
+Local File storage
+------------------
+
 Store files locally:
 
 .. code-block:: ini
 
     kinto.attachment.base_path = /tmp
+
+S3 File Storage
+---------------
 
 Store on Amazon S3:
 

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,10 @@ collections.
 You can overwite that option by passing a ``?gzipped=true`` in the QueryString
 to specifically gzip some files.
 
+By default, the server will serve the gzip file, if you want the HTTP
+client to automatically decompress the file while loading it you can
+specify it when uploading the file by passing a ``?use_content_encoding=true``
+
 
 Attributes
 ----------

--- a/kinto_attachment/tests/__init__.py
+++ b/kinto_attachment/tests/__init__.py
@@ -73,7 +73,7 @@ class BaseWebTest(object):
         return app
 
     def upload(self, files=None, params=[], headers={}, status=None,
-               randomize=True, gzipped=False):
+               randomize=True, gzipped=False, use_content_encoding=False):
         files = files or self.default_files
         headers = headers or self.headers.copy()
         content_type, body = self.app.encode_multipart(params, files)
@@ -85,6 +85,9 @@ class BaseWebTest(object):
 
         if gzipped:
             params['gzipped'] = 'true'
+
+        if use_content_encoding:
+            params['use_content_encoding'] = 'true'
 
         if len(params) > 0:
             endpoint_url = build_url(self.endpoint_uri, **params)

--- a/kinto_attachment/tests/__init__.py
+++ b/kinto_attachment/tests/__init__.py
@@ -81,22 +81,13 @@ class BaseWebTest(object):
 
         params = {}
         if randomize is not None:
-            if randomize:
-                params['randomize'] = 'true'
-            else:
-                params['randomize'] = 'false'
+            params['randomize'] = 'true' if randomize else 'false'
 
         if gzipped is not None:
-            if gzipped:
-                params['gzipped'] = 'true'
-            else:
-                params['gzipped'] = 'false'
+            params['gzipped'] = 'true' if gzipped else 'false'
 
         if use_content_encoding is not None:
-            if use_content_encoding:
-                params['use_content_encoding'] = 'true'
-            else:
-                params['use_content_encoding'] = 'false'
+            params['use_content_encoding'] = 'true' if use_content_encoding else 'false'
 
         if len(params) > 0:
             endpoint_url = build_url(self.endpoint_uri, **params)

--- a/kinto_attachment/tests/__init__.py
+++ b/kinto_attachment/tests/__init__.py
@@ -73,21 +73,30 @@ class BaseWebTest(object):
         return app
 
     def upload(self, files=None, params=[], headers={}, status=None,
-               randomize=True, gzipped=False, use_content_encoding=False):
+               randomize=None, gzipped=None, use_content_encoding=None):
         files = files or self.default_files
         headers = headers or self.headers.copy()
         content_type, body = self.app.encode_multipart(params, files)
         headers['Content-Type'] = content_type
 
         params = {}
-        if not randomize:
-            params['randomize'] = 'false'
+        if randomize is not None:
+            if randomize:
+                params['randomize'] = 'true'
+            else:
+                params['randomize'] = 'false'
 
-        if gzipped:
-            params['gzipped'] = 'true'
+        if gzipped is not None:
+            if gzipped:
+                params['gzipped'] = 'true'
+            else:
+                params['gzipped'] = 'false'
 
-        if use_content_encoding:
-            params['use_content_encoding'] = 'true'
+        if use_content_encoding is not None:
+            if use_content_encoding:
+                params['use_content_encoding'] = 'true'
+            else:
+                params['use_content_encoding'] = 'false'
 
         if len(params) > 0:
             endpoint_url = build_url(self.endpoint_uri, **params)

--- a/kinto_attachment/tests/config/s3_per_resource.ini
+++ b/kinto_attachment/tests/config/s3_per_resource.ini
@@ -1,0 +1,21 @@
+[app:main]
+use = egg:kinto
+kinto.userid_hmac_secret = some-secret-string
+
+kinto.includes = kinto.plugins.default_bucket
+                 kinto_attachment
+
+kinto.attachment.base_url = https://cdn.firefox.net/
+
+kinto.attachment.folder = {bucket_id}/{collection_id}
+
+kinto.attachment.aws.host = localhost
+kinto.attachment.aws.port = 5000
+kinto.attachment.aws.is_secure = false
+kinto.attachment.aws.use_path_style = true
+kinto.attachment.aws.access_key = aws
+kinto.attachment.aws.secret_key = aws
+kinto.attachment.aws.bucket_name = myfiles
+
+kinto.attachment.resources.fennec.gzipped = true
+kinto.attachment.resources.fingerprinting-defenses_fonts.use_content_encoding = true

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -1,5 +1,11 @@
+import pytest
 import unittest
-from kinto_attachment import __version__
+
+from pyramid import testing
+from pyramid.exceptions import ConfigurationError
+from kinto import main as kinto_main
+from kinto_attachment import __version__, includeme
+
 from . import BaseWebTestLocal
 
 
@@ -16,3 +22,33 @@ class HelloViewTest(BaseWebTestLocal, unittest.TestCase):
             "gzipped": False
         }
         self.assertEqual(expected, capabilities["attachments"])
+
+
+class IncludeMeTest(unittest.TestCase):
+    def includeme(self, settings):
+        config = testing.setUp(settings=settings)
+        kinto_main(None, config=config)
+        includeme(config)
+        return config
+
+    def test_includeme_understand_authorized_resources_settings(self):
+        config = self.includeme(settings={
+            "attachment.base_path": "/tmp",
+            "attachment.resources.fennec.gzipped": "true",
+            "attachment.resources.fingerprinting_fonts.use_content_encoding": "true"
+        })
+        assert isinstance(config.registry.attachment_resources, dict)
+        assert '/buckets/fennec' in config.registry.attachment_resources
+        assert '/buckets/fingerprinting/collections/fonts' in config.registry.attachment_resources
+
+    def test_includeme_raises_error_for_malformed_resource_settings(self):
+        with pytest.raises(ConfigurationError) as excinfo:
+            self.includeme(settings={"attachment.resources.fennec.fonts.gzipped": "true"})
+        assert str(excinfo.value) == (
+            'Configuration rule malformed: `attachment.resources.fennec.fonts.gzipped`')
+
+    def test_includeme_raises_error_if_wrong_resource_settings_is_defined(self):
+        with pytest.raises(ConfigurationError) as excinfo:
+            self.includeme(settings={"attachment.resources.fennec.base_path": "foobar"})
+        assert str(excinfo.value) == ('`base_path` is not a supported setting name. '
+                                      'Read `attachment.resources.fennec.base_path`')

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -177,6 +177,12 @@ class AttachmentViewTest(object):
         ], gzipped=True)
         self.assertIn('original', resp.json)
 
+    def test_file_was_zipped_with_content_encoding(self):
+        resp = self.upload(files=[
+            (self.file_field, b'my-report.pdf', b'--binary--')
+        ], gzipped=True, use_content_encoding=True)
+        self.assertIn('original', resp.json)
+
     def test_record_location_contains_subfolder(self):
         self.upload()
         resp = self.app.get(self.record_uri, headers=self.headers)

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -426,7 +426,6 @@ class PerResourceConfigAttachementViewTest(BaseWebTestS3, unittest.TestCase):
         self.checkUseContentTypeS3Response(r, content_encoding=False)
 
 
-
 class SingleAttachmentViewTest(AttachmentViewTest, BaseWebTestLocal,
                                unittest.TestCase):
     pass

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -6,6 +6,7 @@ import unittest
 
 from urllib.parse import urlparse
 from kinto.core.errors import ERRORS
+from kinto_attachment.utils import sha256
 from . import BaseWebTestLocal, BaseWebTestS3, get_user_headers
 
 
@@ -68,6 +69,8 @@ class LocalUploadTest(UploadTest, BaseWebTestLocal, unittest.TestCase):
         self.assertTrue(attachment['location'].endswith('.pdf'))
         self.assertEqual(attachment['mimetype'], 'application/pdf')
         relativeurl = attachment['location'].replace(self.base_url, '')
+        self.assertEqual(attachment['hash'], sha256(b'--binary--'))
+        self.assertEqual(attachment['size'], len(b'--binary--'))
         file_path = os.path.join('/tmp', relativeurl)
         self.assertTrue(os.path.exists(file_path))
         with open(file_path, 'rb') as f:
@@ -83,6 +86,8 @@ class S3UploadTest(UploadTest, BaseWebTestS3, unittest.TestCase):
         self.assertTrue(attachment['location'].endswith('.pdf'))
         self.assertEqual(attachment['mimetype'], 'application/pdf')
         relative_url = attachment['location'].replace(self.base_url, '')
+        self.assertEqual(attachment['hash'], sha256(b'--binary--'))
+        self.assertEqual(attachment['size'], len(b'--binary--'))
         resp = requests.get("http://localhost:5000/myfiles/{}".format(relative_url))
         self.assertEqual(resp.headers['Content-Type'], 'application/pdf')
         self.assertEqual(resp.text, '--binary--')

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -11,6 +11,7 @@ from kinto.core.storage import Filter
 from kinto.views.records import Record
 from kinto.authorization import RouteFactory
 from pyramid import httpexceptions
+from pyramid_storage.local import LocalFileStorage
 from pyramid_storage.exceptions import FileNotAllowed
 
 FILE_LINKS = '__attachments__'
@@ -137,23 +138,37 @@ def save_file(content, request, randomize=True, gzipped=False,
     content.file.seek(0)
     filecontent = content.file.read()
 
-    if gzipped:
+    original = None
+    save_options = {'folder': folder,
+                    'randomize': randomize}
+
+    should_gzip_content = False
+
+    if use_content_encoding:
+        # Http will decompress gzipped data automatically if the header
+        # 'Content-Encoding' is present. So, this mimetype here we can
+        # still use the original one as well as the file name.
+        mimetype = content.type
+        filename = content.filename
+        save_options['headers'] = {
+            'content-type': mimetype,
+            'content-encoding': 'gzip'
+        }
+        should_gzip_content = not isinstance(request.attachment, LocalFileStorage)
+
+    elif gzipped:
         original = {
             'filename': content.filename,
             'hash': sha256(filecontent),
             'mimetype': content.type,
             'size': len(filecontent),
         }
-        if use_content_encoding:
-            # Http will decompress gzipped data automatically if the header
-            # 'Content-Encoding' is present. So, this mimetype here we can
-            # still use the original one as well as the file name.
-            mimetype = content.type
-            filename = content.filename
-        else:
-            mimetype = 'application/x-gzip'
-            filename = content.filename + '.gz'
+        mimetype = 'application/x-gzip'
+        filename = content.filename + '.gz'
+        save_options['extensions'] = ['gz']
+        should_gzip_content = True
 
+    if should_gzip_content:
         # in-memory gzipping
         out = BytesIO()
         with gzip.GzipFile(fileobj=out, mode="w") as f:
@@ -164,20 +179,8 @@ def save_file(content, request, randomize=True, gzipped=False,
         content.file = out
         content.filename = filename
     else:
-        original = None
         mimetype = content.type
         filename = content.filename
-
-    save_options = {'folder': folder,
-                    'randomize': randomize}
-    if gzipped:
-        if use_content_encoding:
-            save_options['headers'] = {
-                'content-type': mimetype,
-                'content-encoding': 'gzip'
-            }
-        else:
-            save_options['extensions'] = ['gz']
 
     try:
         location = request.attachment.save(content, **save_options)

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -137,6 +137,8 @@ def save_file(content, request, randomize=True, gzipped=False,
 
     content.file.seek(0)
     filecontent = content.file.read()
+    filehash = sha256(filecontent)
+    size = len(filecontent)
 
     original = None
     save_options = {'folder': folder,
@@ -159,9 +161,9 @@ def save_file(content, request, randomize=True, gzipped=False,
     elif gzipped:
         original = {
             'filename': content.filename,
-            'hash': sha256(filecontent),
+            'hash': filehash,
             'mimetype': content.type,
-            'size': len(filecontent),
+            'size': size,
         }
         mimetype = 'application/x-gzip'
         filename = content.filename + '.gz'
@@ -178,6 +180,9 @@ def save_file(content, request, randomize=True, gzipped=False,
         out.seek(0)
         content.file = out
         content.filename = filename
+        if not use_content_encoding:
+            filehash = sha256(filecontent)
+            size = len(filecontent)
     else:
         mimetype = content.type
         filename = content.filename
@@ -190,8 +195,6 @@ def save_file(content, request, randomize=True, gzipped=False,
 
     # File metadata.
     fullurl = request.attachment.url(location)
-    size = len(filecontent)
-    filehash = sha256(filecontent)
     attachment = {
         'filename': filename,
         'location': fullurl,

--- a/kinto_attachment/views/__init__.py
+++ b/kinto_attachment/views/__init__.py
@@ -44,15 +44,14 @@ def post_attachment_view(request, file_field):
         'use_content_encoding': asbool(settings.get('attachment.use_content_encoding', False))
     }
 
-    collection_id = '/buckets/{bucket_id}/collections/{collection_id}'.format_map(
-        request.matchdict)
-    bucket_id = '/buckets/{bucket_id}'.format_map(request.matchdict)
+    cid = '/buckets/{bucket_id}/collections/{collection_id}'.format_map(request.matchdict)
+    bid = '/buckets/{bucket_id}'.format_map(request.matchdict)
 
-    if bucket_id in request.registry.attachment_resources:
-        resource_settings.update(request.registry.attachment_resources[bucket_id])
+    if bid in request.registry.attachment_resources:
+        resource_settings.update(request.registry.attachment_resources[bid])
 
-    if collection_id in request.registry.attachment_resources:
-        resource_settings.update(request.registry.attachment_resources[collection_id])
+    if cid in request.registry.attachment_resources:
+        resource_settings.update(request.registry.attachment_resources[cid])
 
     randomize = True
     if 'randomize' in request.GET:

--- a/kinto_attachment/views/__init__.py
+++ b/kinto_attachment/views/__init__.py
@@ -38,15 +38,31 @@ def post_attachment_view(request, file_field):
                          errno=ERRORS.INVALID_POSTED_DATA,
                          message="Attachment missing.")
 
+    # Per resource settings
+    resource_settings = {
+        'gzipped': asbool(settings.get('attachment.gzipped', False)),
+        'use_content_encoding': asbool(settings.get('attachment.use_content_encoding', False))
+    }
+
+    collection_id = '/buckets/{bucket_id}/collections/{collection_id}'.format_map(
+        request.matchdict)
+    bucket_id = '/buckets/{bucket_id}'.format_map(request.matchdict)
+
+    if bucket_id in request.registry.attachment_resources:
+        resource_settings.update(request.registry.attachment_resources[bucket_id])
+
+    if collection_id in request.registry.attachment_resources:
+        resource_settings.update(request.registry.attachment_resources[collection_id])
+
     randomize = True
     if 'randomize' in request.GET:
         randomize = asbool(request.GET['randomize'])
 
-    gzipped = asbool(settings.get('attachment.gzipped', False))
+    gzipped = resource_settings['gzipped']
     if 'gzipped' in request.GET:
         gzipped = asbool(request.GET['gzipped'])
 
-    use_content_encoding = False
+    use_content_encoding = resource_settings['use_content_encoding']
     if 'use_content_encoding' in request.GET:
         use_content_encoding = asbool(request.GET['use_content_encoding'])
 

--- a/kinto_attachment/views/__init__.py
+++ b/kinto_attachment/views/__init__.py
@@ -46,8 +46,13 @@ def post_attachment_view(request, file_field):
     if 'gzipped' in request.GET:
         gzipped = asbool(request.GET['gzipped'])
 
+    use_content_encoding = False
+    if 'use_content_encoding' in request.GET:
+        use_content_encoding = asbool(request.GET['use_content_encoding'])
+
     attachment = utils.save_file(content, request, randomize=randomize,
-                                 gzipped=gzipped)
+                                 gzipped=gzipped,
+                                 use_content_encoding=use_content_encoding)
 
     # Update related record.
     posted_data = {k: v for k, v in request.POST.items() if k != file_field}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,7 @@ universal = 1
 
 [bdist_wheel]
 universal=1
+
+[coverage:run]
+branch = True
+omit = kinto_attachment/tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,4 @@ universal = 1
 universal=1
 
 [coverage:run]
-branch = True
-omit = kinto_attachment/tests/
+omit = kinto_attachment/tests/*


### PR DESCRIPTION
Add a new URL parameter 'use_content_encoding' for post request. If it is true as well as the parameter 'gzipped', attachments will be set with 'Content-Encoding: gzip' header for S3 server and the file extensions will still remain the same as the original one.

https://github.com/Kinto/kinto-attachment/issues/131

