### PR TITLE
Use dot instead of underscore as separator (fixes #134)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIRTUALENV = virtualenv --python python3.5
+VIRTUALENV = virtualenv --python python3.6
 VENV := $(shell echo $${VIRTUAL_ENV-.venv})
 PYTHON = $(VENV)/bin/python
 INSTALL_STAMP = $(VENV)/.install.stamp

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ can use the resource configuration key:
     kinto.attachment.resources.fennec-staging.gzipped = true
 
     # Or for a specific collection in it (/buckets/fingerprinting-defenses-staging/fonts)
-    kinto.attachment.resources.fingerprinting-defenses-staging_fonts.use_content_encoding = true
+    kinto.attachment.resources.fingerprinting-defenses-staging.fonts.use_content_encoding = true
 
 Be careful, ``use_content_encoding`` automatically sets ``gzipped =
 true`` with the S3 storage but the metadata will look like it wasn't

--- a/kinto_attachment/__init__.py
+++ b/kinto_attachment/__init__.py
@@ -19,14 +19,15 @@ def includeme(config):
         if setting_name.startswith('attachment.'):
             if setting_name.startswith('attachment.resources.'):
                 # Resource specific config
-                parts = setting_name.split('.')[2:]
-                if len(parts) == 2:
-                    resource, name = parts
-                    if '_' in resource:
-                        bucket_id, collection_id = resource.rsplit('_', 1)
-                        resource_id = '/buckets/{}/collections/{}'.format(bucket_id, collection_id)
-                    else:
-                        resource_id = '/buckets/{}'.format(resource)
+                parts = setting_name.replace('attachment.resources.', '').split('.')
+                # attachment.resources.{bid}.gzipped
+                # attachment.resources.{bid}.{cid}.gzipped
+                if len(parts) == 3:
+                    bucket_id, collection_id, name = parts
+                    resource_id = '/buckets/{}/collections/{}'.format(bucket_id, collection_id)
+                elif len(parts) == 2:
+                    bucket_id, name = parts
+                    resource_id = '/buckets/{}'.format(bucket_id)
                 else:
                     message = 'Configuration rule malformed: `{}`'.format(setting_name)
                     raise ConfigurationError(message)

--- a/kinto_attachment/tests/config/s3_per_resource.ini
+++ b/kinto_attachment/tests/config/s3_per_resource.ini
@@ -18,4 +18,4 @@ kinto.attachment.aws.secret_key = aws
 kinto.attachment.aws.bucket_name = myfiles
 
 kinto.attachment.resources.fennec.gzipped = true
-kinto.attachment.resources.fingerprinting-defenses_fonts.use_content_encoding = true
+kinto.attachment.resources.fingerprinting-defenses.fonts.use_content_encoding = true

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -35,7 +35,7 @@ class IncludeMeTest(unittest.TestCase):
         config = self.includeme(settings={
             "attachment.base_path": "/tmp",
             "attachment.resources.fennec.gzipped": "true",
-            "attachment.resources.fingerprinting_fonts.use_content_encoding": "true"
+            "attachment.resources.fingerprinting.fonts.use_content_encoding": "true"
         })
         assert isinstance(config.registry.attachment_resources, dict)
         assert '/buckets/fennec' in config.registry.attachment_resources

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -43,9 +43,9 @@ class IncludeMeTest(unittest.TestCase):
 
     def test_includeme_raises_error_for_malformed_resource_settings(self):
         with pytest.raises(ConfigurationError) as excinfo:
-            self.includeme(settings={"attachment.resources.fennec.fonts.gzipped": "true"})
+            self.includeme(settings={"attachment.resources.fen.nec.fonts.gzipped": "true"})
         assert str(excinfo.value) == (
-            'Configuration rule malformed: `attachment.resources.fennec.fonts.gzipped`')
+            'Configuration rule malformed: `attachment.resources.fen.nec.fonts.gzipped`')
 
     def test_includeme_raises_error_if_wrong_resource_settings_is_defined(self):
         with pytest.raises(ConfigurationError) as excinfo:


### PR DESCRIPTION
Fixes #134