### PR TITLE
Do not use Content-Encoding Gzip when upload on S3 (fixes #144)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 4.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- Gzip ``Content-Encoding`` is not used anymore when uploading on S3 (fixes #144)
 
 
 4.0.0 (2018-07-24)

--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -78,22 +78,7 @@ class LocalUploadTest(UploadTest, BaseWebTestLocal, unittest.TestCase):
 
 
 class S3UploadTest(UploadTest, BaseWebTestS3, unittest.TestCase):
-    def test_file_is_served_with_content_encoding_header(self):
-        resp = self.upload(files=[
-            (self.file_field, b'my-report.pdf', b'--binary--')
-        ])
-        attachment = resp.json
-
-        self.assertTrue(attachment['location'].endswith('.pdf'))
-        self.assertEqual(attachment['mimetype'], 'application/pdf')
-        self.assertEqual(attachment['hash'], sha256(b'--binary--'))
-        self.assertEqual(attachment['size'], len(b'--binary--'))
-
-        relative_url = attachment['location'].replace(self.base_url, '')
-        resp = requests.get("http://localhost:5000/myfiles/{}".format(relative_url))
-        self.assertEqual(resp.headers['Content-Type'], 'application/pdf')
-        self.assertEqual(resp.text, '--binary--')
-        self.assertEqual(resp.headers.get('Content-Encoding'), 'gzip')
+    pass
 
 
 class DeleteTest(object):
@@ -379,22 +364,6 @@ class PerResourceConfigAttachementViewTest(BaseWebTestS3, unittest.TestCase):
 
         self.assertNotIn('original', r.json['mimetype'])
         self.assertEqual(r.json['mimetype'], 'image/jpeg')
-
-    def test_file_uses_gzip_encoding(self):
-        self.create_collection('fingerprinting-defenses', 'fonts')
-        record_uri = self.get_record_uri('fingerprinting-defenses', 'fonts', str(uuid.uuid4()))
-        self.endpoint_uri = record_uri + '/attachment'
-        r = self.upload()
-
-        self.assertNotIn('original', r.json['mimetype'])
-        self.assertEqual(r.json['mimetype'], 'image/jpeg')
-        self.assertEqual(r.json['filename'], 'image.jpg')
-
-        relative_url = r.json['location'].replace(self.base_url, '')
-        resp = requests.get("http://localhost:5000/myfiles/{}".format(relative_url))
-        self.assertEqual(resp.headers['Content-Type'], 'image/jpeg')
-        self.assertEqual(resp.text, '--fake--')
-        self.assertEqual(resp.headers.get('Content-Encoding'), 'gzip')
 
 
 class SingleAttachmentViewTest(AttachmentViewTest, BaseWebTestLocal,


### PR DESCRIPTION
Fixes #144 

As said offline, we should investigate #143 first.


