### PR TITLE
Do not allow any file extension by default. Now allow documents+images+text+data (Fix #130, Fix #148)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,13 @@ Changelog
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Breaking changes**
+
+- Do not allow any file extension by default. Now allow documents+images+text+data (Fix #130)
+
+**Bug fixes**
+
+- Fix heartbeat when allowed file types is not ``any`` (Fix #148)
 
 
 5.0.0 (2018-07-31)

--- a/kinto_attachment/__init__.py
+++ b/kinto_attachment/__init__.py
@@ -43,7 +43,7 @@ def includeme(config):
 
     # Force some pyramid_storage settings.
     storage_settings['storage.name'] = 'attachment'
-    storage_settings.setdefault('storage.extensions', 'any')
+    storage_settings.setdefault('storage.extensions', 'default')
     config.add_settings(storage_settings)
 
     # It may be useful to define an additional base_url setting.

--- a/kinto_attachment/tests/config/s3.ini
+++ b/kinto_attachment/tests/config/s3.ini
@@ -10,6 +10,8 @@ kinto.attachment.base_url = https://cdn.firefox.net/
 
 kinto.attachment.folder = {bucket_id}/{collection_id}
 
+storage.extensions = images
+
 kinto.attachment.aws.host = localhost
 kinto.attachment.aws.port = 5000
 kinto.attachment.aws.is_secure = false

--- a/kinto_attachment/views.py
+++ b/kinto_attachment/views.py
@@ -12,7 +12,7 @@ from kinto_attachment import utils
 
 
 HEARTBEAT_CONTENT = '{"test": "write"}'
-HEARTBEAT_FILENAME = 'heartbeat.json'
+HEARTBEAT_FILENAME = 'heartbeat'
 SINGLE_FILE_FIELD = 'attachment'
 
 
@@ -112,10 +112,14 @@ def attachments_ping(request):
     if asbool(request.registry.settings.get('readonly', False)):
         return True
 
+    # We will fake a file upload, so pick a file extension that is allowed.
+    extensions = request.attachment.extensions or {'json'}
+    allowed_extension = "." + list(extensions)[-1]
+
     status = False
     try:
         content = cgi.FieldStorage()
-        content.filename = HEARTBEAT_FILENAME
+        content.filename = HEARTBEAT_FILENAME + allowed_extension
         content.file = BytesIO(HEARTBEAT_CONTENT.encode('utf-8'))
         content.type = 'application/octet-stream'
 


### PR DESCRIPTION
Fix #130, Fix #148