### PR TITLE
Fix broken compatibility with Kinto 13.6.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 6.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix broken compatibility with Kinto 13.6.4
 
 
 6.0.2 (2019-11-13)

--- a/kinto_attachment/utils.py
+++ b/kinto_attachment/utils.py
@@ -33,6 +33,7 @@ class AttachmentRouteFactory(RouteFactory):
             request.validated.setdefault('header', {})
             request.validated.setdefault('querystring', {})
             resource = Record(request, context=self)
+            resource.object_id = request.matchdict['id']
             existing = resource.get()
         except httpexceptions.HTTPNotFound:
             existing = None
@@ -91,6 +92,7 @@ def patch_record(record, request):
 
     request.body = json.dumps(record).encode('utf-8')
     resource = Record(request, context=context)
+    resource.object_id = request.matchdict['id']
     setattr(request, '_attachment_auto_save', True)  # Flag in update listener.
 
     try:


### PR DESCRIPTION
Object ID used to be read from `request.matchdict` on plural POST in `kinto.core` ([source](https://github.com/Kinto/kinto/blob/4da22541541c25d205df16e82575f9ace671f6a5/kinto/core/resource/__init__.py#L193))
This made no sense since no {id} was present in plural URLs. In 13.6.4, it was changed to something smarter for `POST` requests ([source](https://github.com/Kinto/kinto/blob/af5b2492c26d9b0011523339712849f374e38821/kinto/core/resource/__init__.py#L259-L265))

But the hacks in kinto-attachment utils relied on reading the object ID from the URL pattern with POST requests (we POST an attachment on a URL that contains `.../records/{id}/attachment`). To avoid breakage ([example](https://travis-ci.org/github/Kinto/kinto-signer/jobs/668610345#L590)), the helpers that instantiate resources to store attachments had to be adjusted.