### PR TITLE
Force trailing slash in base_url capabilities field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 6.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- ``base_url`` field in server's capabilities will be added a trailing slash (``/``)
+  if missing.
 
 
 6.1.0 (2020-06-23)

--- a/kinto_attachment/__init__.py
+++ b/kinto_attachment/__init__.py
@@ -51,6 +51,10 @@ def includeme(config):
     extra_base_url = settings.get('attachment.extra.base_url',
                                   settings.get('attachment.base_url'))
 
+    # Force trailing slash since attachment locations have no leading slash.
+    if extra_base_url and not extra_base_url.endswith("/"):
+        extra_base_url += "/"
+
     # Expose capability.
     config.add_api_capability("attachments",
                               version=__version__,

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -51,3 +51,10 @@ class IncludeMeTest(unittest.TestCase):
             self.includeme(settings={"attachment.resources.fennec.base_path": "foobar"})
         assert str(excinfo.value) == ('`base_path` is not a supported setting name. '
                                       'Read `attachment.resources.fennec.base_path`')
+
+    def test_base_url_is_added_a_trailing_slash(self):
+        config = self.includeme(settings={
+            "attachment.base_path": "/tmp",
+            "attachment.base_url": "http://cdn.com",
+        })
+        assert config.registry.api_capabilities["attachments"]["base_url"] == "http://cdn.com/"


### PR DESCRIPTION
We realized this while working on https://github.com/mozilla-services/merino/pull/232