### PR TITLE
Include gcloud storage backend automatically

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 6.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- Include the Google Cloud backend automatically when ``kinto.attachment.gcloud.*`` settings are used.
 
 
 6.2.0 (2021-12-02)

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,18 @@ Store on Amazon S3:
 See `Pyramid Storage <https://pythonhosted.org/pyramid_storage/>`_.
 
 
+Google Cloud Storage
+--------------------
+
+.. code-block:: ini
+
+    kinto.attachment.gcloud.credentials = <Path to the Service Accounts credentials JSON file>
+    kinto.attachment.gcloud.bucket_name = <bucket name>
+    kinto.attachment.gcloud.acl = publicRead
+
+See `Google Cloud ACL permissions <https://cloud.google.com/storage/docs/access-control/making-data-public>`_
+
+
 The ``folder`` option
 ---------------------
 

--- a/kinto_attachment/__init__.py
+++ b/kinto_attachment/__init__.py
@@ -69,6 +69,8 @@ def includeme(config):
     # Enable attachment backend.
     if 'storage.base_path' in storage_settings:
         config.include('pyramid_storage.local')
+    elif 'storage.gcloud.credentials' in storage_settings:
+        config.include('pyramid_storage.gcloud')
     else:
         config.include('pyramid_storage.s3')
 

--- a/kinto_attachment/tests/test_plugin_setup.py
+++ b/kinto_attachment/tests/test_plugin_setup.py
@@ -3,6 +3,9 @@ import unittest
 
 from pyramid import testing
 from pyramid.exceptions import ConfigurationError
+from pyramid_storage.interfaces import IFileStorage
+from pyramid_storage.s3 import S3FileStorage
+from pyramid_storage.gcloud import GoogleCloudStorage
 from kinto import main as kinto_main
 from kinto_attachment import __version__, includeme
 
@@ -58,3 +61,17 @@ class IncludeMeTest(unittest.TestCase):
             "attachment.base_url": "http://cdn.com",
         })
         assert config.registry.api_capabilities["attachments"]["base_url"] == "http://cdn.com/"
+
+    def test_gcloud_is_used_if_credentials_setting_is_used(self):
+        config = self.includeme(settings={
+            "attachment.gcloud.credentials": "/path/to/credentials.json",
+            "attachment.gcloud.bucket_name": "foo",
+        })
+        assert isinstance(config.registry.queryUtility(IFileStorage), GoogleCloudStorage)
+
+    def test_s3_is_used_if_base_path_setting_is_not_used(self):
+        config = self.includeme(settings={
+            "attachment.aws.access_key": "abc",
+            "attachment.aws.bucket_name": "foo",
+        })
+        assert isinstance(config.registry.queryUtility(IFileStorage), S3FileStorage)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with codecs.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
 
 requirements = [
     'boto',
+    'google-cloud-storage',
     'kinto<15',  # content-type header in delete responses
     'pyramid_storage>=0.1.0',
 ]


### PR DESCRIPTION
It should be possible to use the Google Cloud storage by adding `pyramid_storage.gcloud` to `kinto.includes` and installing the `google-cloud-storage` dependency manually, but it seems more reasonable to mimic the S3 behavior and do it automatically