### PR TITLE
Catch `TypeError` when `data`/`permissions` are passed as files

### DIFF
--- a/kinto_attachment/tests/test_views_attachment.py
+++ b/kinto_attachment/tests/test_views_attachment.py
@@ -239,6 +239,20 @@ class AttachmentViewTest(object):
         self.assertIn('body: permissions is not valid JSON',
                       resp.json['message'])
 
+    def test_permissions_must_be_str(self):
+        files = [
+            ('attachment', 'image.jpg', b'--fake--'),
+            ('data', 'data', b'{"family": "sans"}'),
+            ('permissions', 'permissions', b'{"read": ["system.Everyone"]}'),
+        ]
+        content_type, body = self.app.encode_multipart([], files)
+        headers = {**self.headers, "Content-Type": content_type}
+
+        resp = self.app.post(self.endpoint_uri, body, headers=headers, status=400)
+
+        self.assertIn("body: 'data' field should be passed as form data, not files",
+                      resp.json["message"])
+
     def test_unknown_fields_are_not_accepted(self):
         resp = self.upload(params=[('my_field', 'a_value')], status=400)
         self.assertIn("body: 'my_field' not in ('data', 'permissions')",

--- a/kinto_attachment/views.py
+++ b/kinto_attachment/views.py
@@ -67,6 +67,11 @@ def post_attachment_view(request, file_field):
         if field in posted_data:
             try:
                 record[field] = json.loads(posted_data.pop(field))
+            except TypeError:
+                error_msg = "body: %r field should be passed as form data, not files" % field
+                raise http_error(httpexceptions.HTTPBadRequest(),
+                                 errno=ERRORS.INVALID_POSTED_DATA,
+                                 message=error_msg)
             except ValueError as e:
                 error_msg = "body: %s is not valid JSON (%s)" % (field, str(e))
                 raise http_error(httpexceptions.HTTPBadRequest(),


### PR DESCRIPTION
This piece of client code crashes the server. 

```py
        record = {
            'attachment': (os.path.basename(WASM_PATH), open(WASM_PATH, 'rb')),
            'data': json.dumps({
                "name": name,
                "release": release,
                "revision": revision,
                "license": license,
                "version": version,
                "fx_release": fx_release,
            })
        }

        response = requests.post(
            url,
            headers={ 'Authorization': self.bearer_token },
            files=record,
        )
```

This PR catches the exception `the JSON object must be str, bytes or bytearray, not cgi_FieldStorage`
