### PR TITLE
Pin Python version to 3.8 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
           - toxenv: py38
             python-version: "3.8"
           - toxenv: upload-download-scripts
-            python-version: "3.X"
+            python-version: "3.8"
           - toxenv: kinto-master
-            python-version: "3.X"
+            python-version: "3.8"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We were using a loosy version (`3.X`) and tests were running with 3.12 for which installation of certain libraries failed