### PR TITLE
Add option to control filenames in storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,16 +142,22 @@ Or a specific collection:
     kinto.attachment.resources.blog.articles.randomize = true
 
 
-The ``datetime_prefix`` option
-------------------------------
+The ``filename_pattern`` option
+-------------------------------
 
-If you want uploaded files to be stored with a date time prefix (default: False):
+If you want uploaded files to be stored with a custom filename pattern (default: original filename):
 
 .. code-block:: ini
 
-    kinto.attachment.datetime_prefix = true
+    kinto.attachment.filename_pattern = {datetime}-{rid}-{filename}
 
-This option is useful to trace uploaded files chronologically, when inspecting trafic or browsing the storage.
+Available placeholders:
+
+- ``{filename}``: the original uploaded filename (or UUID if ``randomize`` is enabled)
+- ``{datetime}``: current date and time formatted as ``YYYYmmddHHMMSS``
+- ``{rid}``: the record ID
+
+This option is useful to trace uploaded files chronologically, when inspecting traffic or browsing the storage.
 It is also useful to avoid name collisions when randomization is disabled.
 
 

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ Available placeholders:
 - ``{rid}``: the record ID
 
 This option is useful to trace uploaded files chronologically, when inspecting traffic or browsing the storage.
-It is also useful to avoid name collisions when randomization is disabled.
+It is also useful to group files by record, or trace the original record where the file was attached before being replaced by another one.
 
 
 The ``extensions`` option

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,20 @@ Or a specific collection:
 
     kinto.attachment.resources.blog.articles.randomize = true
 
+
+The ``datetime_prefix`` option
+------------------------------
+
+If you want uploaded files to be stored with a date time prefix (default: False):
+
+.. code-block:: ini
+
+    kinto.attachment.datetime_prefix = true
+
+This option is useful to trace uploaded files chronologically, when inspecting trafic or browsing the storage.
+It is also useful to avoid name collisions when randomization is disabled.
+
+
 The ``extensions`` option
 -------------------------
 

--- a/src/kinto_attachment/__init__.py
+++ b/src/kinto_attachment/__init__.py
@@ -38,7 +38,7 @@ def includeme(config):
                     message = "Configuration rule malformed: `{}`".format(setting_name)
                     raise ConfigurationError(message)
 
-                if name in ("randomize", "keep_old_files"):
+                if name in ("randomize", "keep_old_files", "datetime_prefix"):
                     config.registry.attachment_resources[resource_id][name] = asbool(setting_value)
                 elif name == "max_size_bytes":
                     config.registry.attachment_resources[resource_id][name] = int(setting_value)

--- a/src/kinto_attachment/__init__.py
+++ b/src/kinto_attachment/__init__.py
@@ -38,8 +38,10 @@ def includeme(config):
                     message = "Configuration rule malformed: `{}`".format(setting_name)
                     raise ConfigurationError(message)
 
-                if name in ("randomize", "keep_old_files", "datetime_prefix"):
+                if name in ("randomize", "keep_old_files"):
                     config.registry.attachment_resources[resource_id][name] = asbool(setting_value)
+                elif name == "filename_pattern":
+                    config.registry.attachment_resources[resource_id][name] = setting_value
                 elif name == "max_size_bytes":
                     config.registry.attachment_resources[resource_id][name] = int(setting_value)
                 else:

--- a/src/kinto_attachment/storage/__init__.py
+++ b/src/kinto_attachment/storage/__init__.py
@@ -1,7 +1,9 @@
 import os
 import re
 import unicodedata
+import urllib
 import uuid
+from datetime import datetime
 
 from pyramid import exceptions as pyramid_exceptions
 from zope.interface import Attribute, Interface
@@ -19,7 +21,15 @@ class IFileStorage(Interface):
     def exists(filename):
         """Return ``True`` if *filename* exists in the store."""
 
-    def save(fs, folder=None, randomize=False, filename_pattern=None, record_id="", replace=False, headers=None):
+    def save(
+        fs,
+        folder=None,
+        randomize=False,
+        filename_pattern=None,
+        record_id="",
+        replace=False,
+        headers=None,
+    ):
         """Persist *fs* (a ``cgi.FieldStorage``-like object) and return the
         stored relative filename.
 
@@ -34,6 +44,29 @@ class IFileStorage(Interface):
 
     def delete(filename):
         """Remove *filename* from the store."""
+
+
+class FileStorage:
+    base_url = ""
+
+    def url(self, filename):
+        return urllib.parse.urljoin(self.base_url, filename)
+
+    def save(self, fs, *args, **kwargs):
+        return self.save_file(fs.file, fs.filename, *args, **kwargs)
+
+    @staticmethod
+    def _prepare_filename(filename, randomize=False, filename_pattern=None, record_id=""):
+        filename = secure_filename(os.path.basename(filename))
+        if randomize:
+            filename = random_filename(filename)
+        if filename_pattern:
+            filename = filename_pattern.format(
+                datetime=datetime.now().strftime("%Y%m%d%H%M%S"),
+                rid=record_id,
+                filename=filename,
+            )
+        return filename
 
 
 def register_file_storage_impl(config, impl):

--- a/src/kinto_attachment/storage/__init__.py
+++ b/src/kinto_attachment/storage/__init__.py
@@ -19,12 +19,13 @@ class IFileStorage(Interface):
     def exists(filename):
         """Return ``True`` if *filename* exists in the store."""
 
-    def save(fs, folder=None, randomize=False, replace=False, headers=None):
+    def save(fs, folder=None, randomize=False, datetime_prefix=False, replace=False, headers=None):
         """Persist *fs* (a ``cgi.FieldStorage``-like object) and return the
         stored relative filename.
 
         :param folder: optional sub-path prepended to the filename.
         :param randomize: replace the original name with a UUID.
+        :param datetime_prefix: prepend the current date and time to the filename.
         :param replace: overwrite if a file with that name already exists.
         :param headers: dict of HTTP headers (used for ``Content-Type``).
         """

--- a/src/kinto_attachment/storage/__init__.py
+++ b/src/kinto_attachment/storage/__init__.py
@@ -19,13 +19,15 @@ class IFileStorage(Interface):
     def exists(filename):
         """Return ``True`` if *filename* exists in the store."""
 
-    def save(fs, folder=None, randomize=False, datetime_prefix=False, replace=False, headers=None):
+    def save(fs, folder=None, randomize=False, filename_pattern=None, record_id="", replace=False, headers=None):
         """Persist *fs* (a ``cgi.FieldStorage``-like object) and return the
         stored relative filename.
 
         :param folder: optional sub-path prepended to the filename.
         :param randomize: replace the original name with a UUID.
-        :param datetime_prefix: prepend the current date and time to the filename.
+        :param filename_pattern: pattern string with ``{datetime}``, ``{rid}``, and ``{filename}``
+            placeholders (e.g. ``{datetime}-{rid}-{filename}``).
+        :param record_id: record ID substituted for ``{rid}`` in *filename_pattern*.
         :param replace: overwrite if a file with that name already exists.
         :param headers: dict of HTTP headers (used for ``Content-Type``).
         """

--- a/src/kinto_attachment/storage/gcloud.py
+++ b/src/kinto_attachment/storage/gcloud.py
@@ -1,18 +1,14 @@
 import mimetypes
-import os
-import urllib
-from datetime import datetime
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.settings import asbool
 from zope.interface import implementer
 
 from . import (
+    FileStorage,
     IFileStorage,
-    random_filename,
     read_settings,
     register_file_storage_impl,
-    secure_filename,
 )
 
 
@@ -37,7 +33,7 @@ DEFAULT_FILE_ACL = "publicRead"
 
 
 @implementer(IFileStorage)
-class GoogleCloudStorage:
+class GoogleCloudStorage(FileStorage):
     @classmethod
     def from_settings(cls, settings, prefix):
         options = (
@@ -124,9 +120,6 @@ class GoogleCloudStorage:
                 "Bucket %s does not exist. Set auto_create_bucket=True to create it." % name
             )
 
-    def url(self, filename):
-        return urllib.parse.urljoin(self.base_url, filename)
-
     def exists(self, name, bucket_name=None):
         if not name:
             try:
@@ -138,9 +131,6 @@ class GoogleCloudStorage:
 
     def delete(self, filename, bucket_name=None):
         self.get_bucket(bucket_name).delete_blob(filename)
-
-    def save(self, fs, *args, **kwargs):
-        return self.save_file(fs.file, fs.filename, *args, **kwargs)
 
     def save_file(
         self,
@@ -155,17 +145,7 @@ class GoogleCloudStorage:
         replace=False,
         headers=None,
     ):
-        filename = secure_filename(os.path.basename(filename))
-
-        if randomize:
-            filename = random_filename(filename)
-
-        if filename_pattern:
-            filename = filename_pattern.format(
-                datetime=datetime.now().strftime("%Y%m%d%H%M%S"),
-                rid=record_id,
-                filename=filename,
-            )
+        filename = self._prepare_filename(filename, randomize, filename_pattern, record_id)
 
         if folder:
             filename = folder + "/" + filename

--- a/src/kinto_attachment/storage/gcloud.py
+++ b/src/kinto_attachment/storage/gcloud.py
@@ -1,6 +1,7 @@
 import mimetypes
 import os
 import urllib
+from datetime import datetime
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.settings import asbool
@@ -148,6 +149,7 @@ class GoogleCloudStorage:
         folder=None,
         bucket_name=None,
         randomize=False,
+        datetime_prefix=False,
         acl=None,
         replace=False,
         headers=None,
@@ -156,6 +158,9 @@ class GoogleCloudStorage:
 
         if randomize:
             filename = random_filename(filename)
+
+        if datetime_prefix:
+            filename = datetime.now().strftime("%Y%m%d%H%M%S-") + filename
 
         if folder:
             filename = folder + "/" + filename

--- a/src/kinto_attachment/storage/gcloud.py
+++ b/src/kinto_attachment/storage/gcloud.py
@@ -149,7 +149,8 @@ class GoogleCloudStorage:
         folder=None,
         bucket_name=None,
         randomize=False,
-        datetime_prefix=False,
+        filename_pattern=None,
+        record_id="",
         acl=None,
         replace=False,
         headers=None,
@@ -159,8 +160,12 @@ class GoogleCloudStorage:
         if randomize:
             filename = random_filename(filename)
 
-        if datetime_prefix:
-            filename = datetime.now().strftime("%Y%m%d%H%M%S-") + filename
+        if filename_pattern:
+            filename = filename_pattern.format(
+                datetime=datetime.now().strftime("%Y%m%d%H%M%S"),
+                rid=record_id,
+                filename=filename,
+            )
 
         if folder:
             filename = folder + "/" + filename

--- a/src/kinto_attachment/storage/local.py
+++ b/src/kinto_attachment/storage/local.py
@@ -1,16 +1,13 @@
 import os
 import shutil
-import urllib
-from datetime import datetime
 
 from zope.interface import implementer
 
 from . import (
+    FileStorage,
     IFileStorage,
-    random_filename,
     read_settings,
     register_file_storage_impl,
-    secure_filename,
 )
 
 
@@ -20,7 +17,7 @@ def includeme(config):
 
 
 @implementer(IFileStorage)
-class LocalFileStorage:
+class LocalFileStorage(FileStorage):
     @classmethod
     def from_settings(cls, settings, prefix):
         options = (
@@ -34,9 +31,6 @@ class LocalFileStorage:
         self.base_path = base_path
         self.base_url = base_url
 
-    def url(self, filename):
-        return urllib.parse.urljoin(self.base_url, filename)
-
     def path(self, filename):
         return os.path.join(self.base_path, filename)
 
@@ -49,27 +43,21 @@ class LocalFileStorage:
             return True
         return False
 
-    def save(self, fs, *args, **kwargs):
-        return self.save_file(fs.file, fs.filename, *args, **kwargs)
-
     def save_file(
-        self, file, filename, folder=None, randomize=False, filename_pattern=None, record_id="", **kwargs
+        self,
+        file,
+        filename,
+        folder=None,
+        randomize=False,
+        filename_pattern=None,
+        record_id="",
+        **kwargs,
     ):
-        filename = secure_filename(os.path.basename(filename))
+        filename = self._prepare_filename(filename, randomize, filename_pattern, record_id)
 
         dest_folder = os.path.join(self.base_path, folder) if folder else self.base_path
         if not os.path.exists(dest_folder):
             os.makedirs(dest_folder)
-
-        if randomize:
-            filename = random_filename(filename)
-
-        if filename_pattern:
-            filename = filename_pattern.format(
-                datetime=datetime.now().strftime("%Y%m%d%H%M%S"),
-                rid=record_id,
-                filename=filename,
-            )
 
         filename, path = self._resolve_name(filename, dest_folder)
 

--- a/src/kinto_attachment/storage/local.py
+++ b/src/kinto_attachment/storage/local.py
@@ -53,7 +53,7 @@ class LocalFileStorage:
         return self.save_file(fs.file, fs.filename, *args, **kwargs)
 
     def save_file(
-        self, file, filename, folder=None, randomize=False, datetime_prefix=False, **kwargs
+        self, file, filename, folder=None, randomize=False, filename_pattern=None, record_id="", **kwargs
     ):
         filename = secure_filename(os.path.basename(filename))
 
@@ -64,8 +64,12 @@ class LocalFileStorage:
         if randomize:
             filename = random_filename(filename)
 
-        if datetime_prefix:
-            filename = datetime.now().strftime("%Y%m%d%H%M%S-") + filename
+        if filename_pattern:
+            filename = filename_pattern.format(
+                datetime=datetime.now().strftime("%Y%m%d%H%M%S"),
+                rid=record_id,
+                filename=filename,
+            )
 
         filename, path = self._resolve_name(filename, dest_folder)
 

--- a/src/kinto_attachment/storage/local.py
+++ b/src/kinto_attachment/storage/local.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import urllib
+from datetime import datetime
 
 from zope.interface import implementer
 
@@ -51,7 +52,9 @@ class LocalFileStorage:
     def save(self, fs, *args, **kwargs):
         return self.save_file(fs.file, fs.filename, *args, **kwargs)
 
-    def save_file(self, file, filename, folder=None, randomize=False, **kwargs):
+    def save_file(
+        self, file, filename, folder=None, randomize=False, datetime_prefix=False, **kwargs
+    ):
         filename = secure_filename(os.path.basename(filename))
 
         dest_folder = os.path.join(self.base_path, folder) if folder else self.base_path
@@ -60,6 +63,9 @@ class LocalFileStorage:
 
         if randomize:
             filename = random_filename(filename)
+
+        if datetime_prefix:
+            filename = datetime.now().strftime("%Y%m%d%H%M%S-") + filename
 
         filename, path = self._resolve_name(filename, dest_folder)
 

--- a/src/kinto_attachment/utils.py
+++ b/src/kinto_attachment/utils.py
@@ -186,6 +186,8 @@ def delete_attachment(request, link_field=None, uri=None, keep_old_files=False):
 
 def save_file(request, content, folder=None, keep_link=True, replace=False):
     randomize = setting_value(request, "randomize", default=True)
+    filename_pattern = setting_value(request, "filename_pattern", default=None)
+    record_id = request.matchdict.get("id", "")
 
     overriden_mimetypes = {**DEFAULT_MIMETYPES}
     conf_mimetypes = setting_value(request, "mimetypes", default="")
@@ -223,6 +225,8 @@ def save_file(request, content, folder=None, keep_link=True, replace=False):
     save_options = {
         "folder": folder,
         "randomize": randomize,
+        "filename_pattern": filename_pattern,
+        "record_id": record_id,
         "replace": replace,
         "headers": {"Content-Type": mimetype},
     }

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -123,7 +123,7 @@ class TestGoogleCloudStorage(unittest.TestCase):
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_filename_pattern_datetime(self):
-        with mock.patch("kinto_attachment.storage.gcloud.datetime") as mock_datetime:
+        with mock.patch("kinto_attachment.storage.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
             name = self.storage.save_file(
                 io.BytesIO(b"data"), "file.txt", filename_pattern="{datetime}-{filename}"
@@ -132,7 +132,7 @@ class TestGoogleCloudStorage(unittest.TestCase):
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_filename_pattern_with_rid(self):
-        with mock.patch("kinto_attachment.storage.gcloud.datetime") as mock_datetime:
+        with mock.patch("kinto_attachment.storage.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
             name = self.storage.save_file(
                 io.BytesIO(b"data"),

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import unittest
 from unittest import mock
@@ -119,6 +120,13 @@ class TestGoogleCloudStorage(unittest.TestCase):
         name = self.storage.save_file(io.BytesIO(b"data"), "original.jpg", randomize=True)
         self.assertNotEqual(name, "original.jpg")
         self.assertTrue(name.endswith(".jpg"))
+        self.assertTrue(self.storage.exists(name))
+
+    def test_save_file_datetime_prefixes_filename(self):
+        with mock.patch("kinto_attachment.storage.gcloud.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
+            name = self.storage.save_file(io.BytesIO(b"data"), "file.txt", datetime_prefix=True)
+        self.assertEqual(name, "20240601010101-file.txt")
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_skips_existing_when_no_replace(self):

--- a/tests/storage/test_gcloud.py
+++ b/tests/storage/test_gcloud.py
@@ -122,11 +122,25 @@ class TestGoogleCloudStorage(unittest.TestCase):
         self.assertTrue(name.endswith(".jpg"))
         self.assertTrue(self.storage.exists(name))
 
-    def test_save_file_datetime_prefixes_filename(self):
+    def test_save_file_filename_pattern_datetime(self):
         with mock.patch("kinto_attachment.storage.gcloud.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
-            name = self.storage.save_file(io.BytesIO(b"data"), "file.txt", datetime_prefix=True)
+            name = self.storage.save_file(
+                io.BytesIO(b"data"), "file.txt", filename_pattern="{datetime}-{filename}"
+            )
         self.assertEqual(name, "20240601010101-file.txt")
+        self.assertTrue(self.storage.exists(name))
+
+    def test_save_file_filename_pattern_with_rid(self):
+        with mock.patch("kinto_attachment.storage.gcloud.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
+            name = self.storage.save_file(
+                io.BytesIO(b"data"),
+                "file.txt",
+                filename_pattern="{datetime}-{rid}-{filename}",
+                record_id="abc123",
+            )
+        self.assertEqual(name, "20240601010101-abc123-file.txt")
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_skips_existing_when_no_replace(self):

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -1,8 +1,10 @@
+import datetime
 import io
 import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from pyramid.exceptions import ConfigurationError
 
@@ -86,6 +88,13 @@ class TestLocalFileStorage(unittest.TestCase):
         name = self.storage.save_file(io.BytesIO(b"data"), "original.jpg", randomize=True)
         self.assertNotEqual(name, "original.jpg")
         self.assertTrue(name.endswith(".jpg"))
+        self.assertTrue(self.storage.exists(name))
+
+    def test_save_file_datetime_prefixes_filename(self):
+        with mock.patch("kinto_attachment.storage.local.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
+            name = self.storage.save_file(io.BytesIO(b"data"), "file.txt", datetime_prefix=True)
+        self.assertEqual(name, "20240601010101-file.txt")
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_resolves_name_collision(self):

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -91,7 +91,7 @@ class TestLocalFileStorage(unittest.TestCase):
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_filename_pattern_datetime(self):
-        with mock.patch("kinto_attachment.storage.local.datetime") as mock_datetime:
+        with mock.patch("kinto_attachment.storage.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
             name = self.storage.save_file(
                 io.BytesIO(b"data"), "file.txt", filename_pattern="{datetime}-{filename}"
@@ -100,7 +100,7 @@ class TestLocalFileStorage(unittest.TestCase):
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_filename_pattern_with_rid(self):
-        with mock.patch("kinto_attachment.storage.local.datetime") as mock_datetime:
+        with mock.patch("kinto_attachment.storage.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
             name = self.storage.save_file(
                 io.BytesIO(b"data"),

--- a/tests/storage/test_local.py
+++ b/tests/storage/test_local.py
@@ -90,11 +90,25 @@ class TestLocalFileStorage(unittest.TestCase):
         self.assertTrue(name.endswith(".jpg"))
         self.assertTrue(self.storage.exists(name))
 
-    def test_save_file_datetime_prefixes_filename(self):
+    def test_save_file_filename_pattern_datetime(self):
         with mock.patch("kinto_attachment.storage.local.datetime") as mock_datetime:
             mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
-            name = self.storage.save_file(io.BytesIO(b"data"), "file.txt", datetime_prefix=True)
+            name = self.storage.save_file(
+                io.BytesIO(b"data"), "file.txt", filename_pattern="{datetime}-{filename}"
+            )
         self.assertEqual(name, "20240601010101-file.txt")
+        self.assertTrue(self.storage.exists(name))
+
+    def test_save_file_filename_pattern_with_rid(self):
+        with mock.patch("kinto_attachment.storage.local.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.datetime(2024, 6, 1, 1, 1, 1)
+            name = self.storage.save_file(
+                io.BytesIO(b"data"),
+                "file.txt",
+                filename_pattern="{datetime}-{rid}-{filename}",
+                record_id="abc123",
+            )
+        self.assertEqual(name, "20240601010101-abc123-file.txt")
         self.assertTrue(self.storage.exists(name))
 
     def test_save_file_resolves_name_collision(self):

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -42,11 +42,16 @@ class IncludeMeTest(unittest.TestCase):
                 "attachment.base_path": "/tmp",
                 "attachment.resources.fennec.keep_old_files": "true",
                 "attachment.resources.fingerprinting.fonts.randomize": "true",
+                "attachment.resources.fennec.filename_pattern": "{datetime}-{rid}-{filename}",
             }
         )
         assert isinstance(config.registry.attachment_resources, dict)
         assert "/buckets/fennec" in config.registry.attachment_resources
         assert "/buckets/fingerprinting/collections/fonts" in config.registry.attachment_resources
+        assert (
+            config.registry.attachment_resources["/buckets/fennec"]["filename_pattern"]
+            == "{datetime}-{rid}-{filename}"
+        )
 
     def test_includeme_raises_error_for_malformed_resource_settings(self):
         with pytest.raises(ConfigurationError) as excinfo:


### PR DESCRIPTION
I think this is cheap to implement, and could have two use-cases:
- have insights about publication date and associated record when looking at graphs like "most expensive URLs"
- being able to group attachments by record ID without having to look at collection history when implementing the compression job for CDT 