### PR TITLE
Fix IntegrityError in `resource_name` migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,10 @@ jobs:
       - name: Post migration functional test
         run: |
           /usr/bin/openssl rand -base64 -out image4.png 3000
+          /usr/bin/openssl rand -base64 -out image5.png 3000
           uv run python scripts/upload.py \
             --server=http://localhost:8888/v1 \
             --bucket=services \
             --collection=logs \
             --auth=my-user:my-secret \
-            image4.png
+            image4.png image5.png

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,5 +103,12 @@ jobs:
           pkill -f "http.server" || true
           make run-kinto & sleep 2
 
-      - name: Run functional tests post migration
-        run: make functional
+      - name: Post migration functional test
+        run: |
+          /usr/bin/openssl rand -base64 -out image4.png 3000
+          uv run python scripts/upload.py \
+            --server=http://localhost:8888/v1 \
+            --bucket=services \
+            --collection=logs \
+            --auth=my-user:my-secret \
+            image4.png

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+    env:
+      # We don't want to run `uv sync` to run implicitly on each `uv run` command
+      # in the middle of the downgrade/migration part of the workflow.
+      UV_NO_SYNC: 1
     steps:
       - uses: actions/checkout@v6
 
@@ -81,8 +85,23 @@ jobs:
       - name: Install dependencies
         run: make install
 
+      - name: Downgrade first to test migrations
+        run: uv pip install "kinto-attachment<9"
+
       - name: Run kinto
         run: make run-kinto & sleep 5
 
       - name: Run functional tests
+        run: make functional
+
+      - name: Upgrade to local `kinto-attachment` version
+        run: make install
+
+      - name: Migrate and restart kinto
+        run: |
+          pkill -f "kinto start" || true
+          pkill -f "http.server" || true
+          make run-kinto & sleep 2
+
+      - name: Run functional tests post migration
         run: make functional

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -18,11 +18,11 @@ def sha256(content):
 
 
 def files_to_upload(records, files, force=False):
-    records_by_id = {r['id']: r for r in records if 'attachment' in r}
-    existing_files = {r['attachment']['filename']: r for r in records if 'attachment' in r}
+    records_by_id = {r['id']: r for r in records if r.get('attachment')}
+    existing_files = {r['attachment']['filename']: r for r in records if r.get('attachment')}
     existing_original_files = {r['attachment']['original']['filename']: r
                                for r in records
-                               if 'attachment' in r and 'original' in r['attachment']}
+                               if r.get('attachment') and 'original' in r['attachment']}
     to_upload = []
     for filepath in files:
         filename = os.path.basename(filepath)

--- a/src/kinto_attachment/migrations.py
+++ b/src/kinto_attachment/migrations.py
@@ -36,8 +36,8 @@ class KintoAttachmentMigration(PostgreSQLPluginMigration):
         logger.info(f"Found {existing[0]} attachment records to migrate.")
 
         sql = """
-        INSERT INTO objects (id, resource_name, parent_id, data)
-            SELECT id, 'attachments', parent_id, data
+        INSERT INTO objects (id, resource_name, deleted, parent_id, data)
+            SELECT id, 'attachments', deleted, parent_id, data
             FROM objects
             WHERE parent_id = '__attachments__' AND resource_name = ''
             ON CONFLICT do nothing;

--- a/tests/config/functional.ini
+++ b/tests/config/functional.ini
@@ -13,6 +13,8 @@ kinto.experimental_collection_schema_validation = true
 
 kinto.storage_backend = kinto.core.storage.postgresql
 kinto.storage_url = postgresql://postgres:postgres@localhost/testdb
+kinto.permission_backend = kinto.core.permission.postgresql
+kinto.permission_url     = postgresql://postgres:postgres@localhost/testdb
 
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.accounts


### PR DESCRIPTION
```
IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "deleted" of relation "objects" violates not-null constraint
DETAIL:  Failing row contains (7c6ada7d-e5c9-4536-9bc0-981b960e3979, __attachments__, attachments, 2026-05-12 15:17:06.7...
```